### PR TITLE
chore: update redux-actions@0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "lodash": "3.10.x",
     "immutable": "^3.7.4",
-    "redux-actions": "0.7.x"
+    "redux-actions": "0.8.x"
   },
   "peerDependencies": {
     "redux": "^1.0.0 || 1.0.0-alpha || 1.0.0-rc"


### PR DESCRIPTION
https://github.com/acdlite/redux-actions/releases/tag/v0.8.0

```
npm WARN unmet dependency /node_modules/redux-storage requires redux-actions@'0.7.x' but will load
npm WARN unmet dependency /node_modules/redux-actions,
npm WARN unmet dependency which is version 0.8.0
```