### PR TITLE
Return new state object on reducer LOAD

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,7 +5,7 @@ import { LOAD } from './constants';
 export default function(reducer) {
     return (state, action) => reducer(
         action.type === LOAD
-            ? merge(state, action.payload)
+            ? merge({}, state, action.payload)
             : state,
         action
     );


### PR DESCRIPTION
Reducer should, on load, return a NEW state object, instead of modifying state. Without this, it doesn't pass new state (reliably, at least) into components after load.