### PR TITLE
Update redux in peerDependencies to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "redux-actions": "0.8.x"
   },
   "peerDependencies": {
-    "redux": "^2.0.0 || ^1.0.0 || 1.0.0-alpha || 1.0.0-rc"
+    "redux": "^3.0.0 || ^2.0.0 || ^1.0.0 || 1.0.0-alpha || 1.0.0-rc"
   }
 }


### PR DESCRIPTION
The only breaking change is that action requires `type` attribute. The only action
here has one.

I tested it well in production app with redux 3.0.0.
The purpose of this PR is to get rid of peerDependencies requirements errors