### PR TITLE
Fix Filter decorator with nested key paths of null

### DIFF
--- a/src/decorators/filter.js
+++ b/src/decorators/filter.js
@@ -19,6 +19,10 @@ export default (engine, whitelist = []) => {
                 }
 
                 key.forEach((keyPart) => {
+                    // If we get to a point where there is a null or undefined
+                    // value, we stop walking down the key path
+                    if (value === undefined || value === null) { return; }
+
                     // Support immutable structures
                     if (isFunction(value.has) && isFunction(value.get)) {
                         if (!value.has(keyPart)) {
@@ -27,11 +31,9 @@ export default (engine, whitelist = []) => {
                         }
 
                         value = value.get(keyPart);
-                    } else if (value[keyPart]) {
-                        value = value[keyPart];
                     } else {
-                        // No value stored
-                        return;
+                        // Always make sure to write out the value
+                        value = value[keyPart];
                     }
 
                     set(saveState, key, value);


### PR DESCRIPTION
There is a bug in the filter decorator when using nested key paths. If the nested key path value is `null`. The key path one level higher is written. As an example:

```js
const simpleEngine = {
  save(state) {
    console.log('final state:', state);
  }
};

const basicFilteredEngine = storage.decorators.filter(simpleEngine, [
  ['a']
]);

const nestedFilteredEngine = storage.decorators.filter(simpleEngine, [
  ['a', 'first']
]);

const data = {
  a: {
    first: null,
    second: 2
  }
};

console.log('Simple Engine');
simpleEngine.save(data);

console.log('Basic Filtered Engine');
basicFilteredEngine.save(data);

console.log('Nested Filtered Engine');
nestedFilteredEngine.save(data);
```

This prints out:

```
Simple Engine
final state: {
    a: {
        first: null,
        second: 2
    }
}
Basic Filtered Engine
final state: {
    a: {
        first: null,
        second: 2
    }
}
Nested Filtered Engine
final state: {
    a: {
        first: {
            first: null,
            second: 2
        }
    }
}
```

As you can see, when the value of `a.first` is `null`, the saved data structure is corrupted.

This PR ensures that a null or undefined value will properly set the state tree.