### PR TITLE
Handle `null` or `undefined` while merge state

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "immutable": "^3.7.5",
     "lodash.isarray": "^3.0.4",
     "lodash.isfunction": "^3.0.6",
+    "lodash.isnull": "^3.0.0",
     "lodash.isobject": "^3.0.2",
+    "lodash.isundefined": "^3.0.1",
     "lodash.merge": "^3.3.2",
     "lodash.set": "^3.7.4",
     "redux-actions": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -55,9 +55,7 @@
     "immutable": "^3.7.5",
     "lodash.isarray": "^3.0.4",
     "lodash.isfunction": "^3.0.6",
-    "lodash.isnull": "^3.0.0",
     "lodash.isobject": "^3.0.2",
-    "lodash.isundefined": "^3.0.1",
     "lodash.merge": "^3.3.2",
     "lodash.set": "^3.7.4",
     "redux-actions": "^0.9.0"

--- a/src/__tests__/reducer-test.js
+++ b/src/__tests__/reducer-test.js
@@ -106,5 +106,15 @@ describe('reducer', () => {
 
             spy.should.have.been.calledWith({ x: 1337 }, action);
         });
+
+        it('should properly merge if old state values with null or undefined', () => {
+            const spy = sinon.spy();
+            const oldState = { x: null, y: void(0) };
+            const action = { type: LOAD, payload: { x: 1337, y: 1338 } };
+
+            reducer(spy)(oldState, action);
+
+            spy.should.have.been.calledWith({ x: 1337, y: 1338 }, action);
+        });
     });
 });

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,8 +1,6 @@
 import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
 import isArray from 'lodash.isarray';
-import isNull from 'lodash.isnull';
-import isUndefined from 'lodash.isundefined';
 import merge from 'lodash.merge';
 import { fromJS } from 'immutable';
 
@@ -40,16 +38,12 @@ function myMerge(oldState, newState) {
 
         const oldValue = result[key];
 
-        if (!isNull(oldValue) && !isUndefined(oldValue)) {
-            if (isFunction(oldValue.mergeDeep)) {
-                result[key] = oldValue.mergeDeep(value);
-            } else if (isFunction(value.mergeDeep)) {
-                result[key] = fromJS(oldValue).mergeDeep(value);
-            } else if (isObject(value) && !isArray(value)) {
-                result[key] = merge({}, oldValue, value);
-            } else {
-                result[key] = value;
-            }
+        if (!!oldValue && isFunction(oldValue.mergeDeep)) {
+            result[key] = oldValue.mergeDeep(value);
+        } else if (!!value && isFunction(value.mergeDeep)) {
+            result[key] = fromJS(oldValue).mergeDeep(value);
+        } else if (isObject(value) && !isArray(value)) {
+            result[key] = merge({}, oldValue, value);
         } else {
             result[key] = value;
         }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -39,7 +39,7 @@ function myMerge(oldState, newState) {
         }
 
         const oldValue = result[key];
-        
+
         if (!isNull(oldValue) && !isUndefined(oldValue)) {
             if (isFunction(oldValue.mergeDeep)) {
                 result[key] = oldValue.mergeDeep(value);


### PR DESCRIPTION
Added special condition to avoid type errors like `Uncaught TypeError: Cannot read property 'mergeDeep' of null`