### PR TITLE
Bump lodash.merge to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.7",
     "lodash.isobject": "^3.0.2",
-    "lodash.merge": "^4.0.1",
+    "lodash.merge": "^4.0.2",
     "lodash.set": "^4.0.0",
     "redux-actions": "^0.9.0"
   },


### PR DESCRIPTION
lodash.merge has a bug in 4.0.1 that causes source objects to be mutated