### PR TITLE
Never reject with undefined

### DIFF
--- a/src/decorators/debounce.js
+++ b/src/decorators/debounce.js
@@ -10,7 +10,7 @@ export default (engine, ms) => {
         save(state) {
             clearTimeout(lastTimeout);
             if (lastReject) {
-                lastReject(Error("Debounced, newer action pending"));
+                lastReject(Error('Debounced, newer action pending'));
                 lastReject = null;
             }
 

--- a/src/decorators/debounce.js
+++ b/src/decorators/debounce.js
@@ -10,7 +10,7 @@ export default (engine, ms) => {
         save(state) {
             clearTimeout(lastTimeout);
             if (lastReject) {
-                lastReject();
+                lastReject(Error("Debounced, newer action pending"));
                 lastReject = null;
             }
 


### PR DESCRIPTION
That's like `throw`ing undefined, there is no context and it's impossible for users to be aware of what happened.

Even doing something simple like rejecting with an `Error` helps here. 

I'm not sure what's the point of even rejecting here semantically (vs. not fulfilling) - it doesn't make a lot of sense and introduces abort and control at a distance semantics which are highly discouraged when using promises.

Cheers and thanks for the library.