### PR TITLE
Change error message and fix a typo

### DIFF
--- a/src/createMiddleware.js
+++ b/src/createMiddleware.js
@@ -30,10 +30,10 @@ function isValidAction(action) {
     if (process.env.NODE_ENV !== 'production') {
         if (isFunc) {
             console.warn( // eslint-disable-line no-console
-                `[redux-storage] ACTION IGNORED! Actions should be objectes`
+                `[redux-storage] ACTION IGNORED! Actions should be objects`
                 + ` with a type property but received a function! Maybe your`
-                + ` function resolving middleware (e.g. redux-thunk) is placed`
-                + ` before redux-storage?`
+                + ` function resolving middleware (e.g. redux-thunk) should be`
+                + ` placed before redux-storage?`
             );
         } else if (!isObj) {
             console.warn( // eslint-disable-line no-console


### PR DESCRIPTION
I noticed this in my project. I initially had my middleware like this
```
applyMiddleware(storageMiddleware, thunkMiddleware, reduxRouterMiddleware, loggerMiddleware)(createStore);
```
and got error message:
```
[redux-storage] ACTION IGNORED! Actions should be objectes with a type property but received a function! Maybe your function resolving middleware (e.g. redux-thunk) is placed before redux-storage?
```
I'm no English native but I think this indicates that I'm doing it right and it still fails.

So I changed thunk middleware before storage like this
```
applyMiddleware(thunkMiddleware, storageMiddleware, reduxRouterMiddleware, loggerMiddleware)(createStore);
```
and the error disappeared.

Hence, I'd propose this PR to change the error message to a bit more correct one :)