### PR TITLE
Allow passing engine options in `load()`

### DIFF
--- a/src/createLoader.js
+++ b/src/createLoader.js
@@ -1,8 +1,8 @@
 import { load as actionLoad } from './actions';
 
-export default (engine) => (store) => {
+export default (engine) => (store, ...engineOpts) => {
     const dispatchLoad = (state) => store.dispatch(actionLoad(state));
-    return engine.load().then((newState) => {
+    return engine.load(...engineOpts).then((newState) => {
         dispatchLoad(newState);
         return newState;
     });


### PR DESCRIPTION
For #140.

This backwards-compatible change allows you to pass options to the engine as part of the `load()` call, e.g.

```js
const load = storage.createLoader(engine);
// ...
load(store, 'my-save-key', { foo: 'bar' });
```

For example, a localForage engine can be implemented like this:
```js
// localForageEngine.js

import localforage from 'localforage';

export default function createEngine() {
  let key;
  let engineConfig;
  return {
    load(...engineOpts) {
      if (!engineConfig) {
        [key, engineConfig] = engineOpts;
        localforage.config(engineConfig);
      }
      return localforage.getItem(key);
    },

    save(state) {
      if (!engineConfig) {
        throw new Error('LocalForage is not configured; you must call `load(config)`');
      }
      return localforage.setItem(key, state);
    },
  };
}

```