### PR TITLE
allow whitelist to be a function

### DIFF
--- a/src/__tests__/createMiddleware-test.js
+++ b/src/__tests__/createMiddleware-test.js
@@ -96,6 +96,20 @@ describe('createMiddleware', () => {
         engine.save.should.have.been.called;
     });
 
+    it('should allow whitelist function', () => {
+        const engine = { save: sinon.stub().resolves() };
+        const store = { getState: sinon.spy() };
+        const next = sinon.spy();
+        const action = { type: 'ALLOWED' };
+        const whitelistFn = (type) => {
+            return type === 'ALLOWED';
+        };
+
+        createMiddleware(engine, [], whitelistFn)(store)(next)(action);
+
+        engine.save.should.have.been.called;
+    });
+
     describeConsoleWarnInNonProduction(
         'should not process functions',
         () => {

--- a/src/createMiddleware.js
+++ b/src/createMiddleware.js
@@ -51,12 +51,20 @@ function isValidAction(action) {
     return false;
 }
 
+function handleWhitelist(action, actionWhitelist) {
+    if (Array.isArray(actionWhitelist)) {
+        // Don't filter if the whitelist is empty
+        return actionWhitelist.length === 0 ? true : actionWhitelist.indexOf(action.type) !== -1;
+    }
+    // actionWhitelist is a function that returns true or false
+    return actionWhitelist(action.type);
+}
 
 export default (engine, actionBlacklist = [], actionWhitelist = []) => {
     // Also don't save if we process our own actions
     const blacklistedActions = [...actionBlacklist, LOAD, SAVE];
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && Array.isArray(actionWhitelist)) {
         warnAboutConfusingFiltering(actionBlacklist, actionWhitelist);
     }
 
@@ -69,9 +77,7 @@ export default (engine, actionBlacklist = [], actionWhitelist = []) => {
             }
 
             const isOnBlacklist = blacklistedActions.indexOf(action.type) !== -1;
-            const isOnWhitelist = actionWhitelist.length === 0
-                ? true // Don't filter if the whitelist is empty
-                : actionWhitelist.indexOf(action.type) !== -1;
+            const isOnWhitelist = handleWhitelist(action, actionWhitelist);
 
             // Skip blacklisted actions
             if (!isOnBlacklist && isOnWhitelist) {


### PR DESCRIPTION
A pretty standard practice is for 3rd party reducers to use a prefix for all of their actions (eg `redux-form/DESTROY`). In my use case, I'd like to disallow _every_ action triggered by a certain 3rd party reducer (eg every action that begins with `redux-form/`) . 

Today, I'd have to know & list every single action that a 3rd party reducer can create. That's a long list. Plus, I run the risk of the list going stale when my 3rd party package updates or changes a constant.

I can accomplish what I want by iterating over the entire blacklist & checking to see if my blacklisted substring is found in each entry. However, your logic may differ. 

That's why if we allow the whitelist to be a function, everyone wins. For example, I'd write something like this: 
```
const whitelistFn = type => {
    const blacklistPrefixes = ['redux-form/', '@@router/'];
    for (let i = 0; i < blacklistPrefixes.length; i++) {
        const prefix = blacklistPrefixes[i];
        if (type.indexOf(prefix) !== -1) {
            return false;
        }
    }
    return true;
}
```

And you can use whatever logic you like. 
The idea is borrowed from webpack, where a bunch of config fields can either be an array or a function.